### PR TITLE
fix(CStage): AddTrigger return bool result

### DIFF
--- a/addons/sourcemod/scripting/AdminRoom.sp
+++ b/addons/sourcemod/scripting/AdminRoom.sp
@@ -35,7 +35,7 @@ public Plugin myinfo =
 	name = "Admin Room",
 	author = "IT-KILLER, BotoX, maxime1907, .Rushaway",
 	description = "Teleport to admin rooms and change stages.",
-	version = "2.1.5",
+	version = "2.1.6",
 	url = ""
 };
 

--- a/addons/sourcemod/scripting/include/CAdminRoom.inc
+++ b/addons/sourcemod/scripting/include/CAdminRoom.inc
@@ -150,7 +150,10 @@ methodmap CStage < Basic
 		{
 			cTriggers.Push(cTrigger);
 			this.SetValue("cTriggers", cTriggers);
+			return true;
 		}
+
+		return false;
 	}
 
 	public bool GetActions(ArrayList &cActions)


### PR DESCRIPTION
`CStage.AddTrigger` was silently discarding its insertion result, making it impossible for callers to know whether the trigger was successfully registered.

**Changes:**
- `CStage.AddTrigger` now returns a proper `bool` success flag
- Callers can now handle failure cases explicitly
- Bumps `PLUGIN_VERSION` `2.1.5` → `2.1.6`

**Why it matters:**
Silent failures in trigger registration could lead to subtle runtime bugs where a stage behaves as if a trigger is active when it was never added. This fix makes the contract explicit and allows defensive error handling upstream.