### PR TITLE
fix(ci): add missing checkout to tag job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
+
       - uses: dev-drprasad/delete-tag-and-release@v1.1
         with:
           delete_release: true


### PR DESCRIPTION
The `tag` job in the new CI workflow (#30) never checks out the repo, so `rickstaa/action-create-tag@v1` (which runs local git commands) fails with `fatal: not a git repository (or any parent up to mount point /github)`. Confirmed on the live run after merging #30: https://github.com/srcdslab/sm-plugin-AdminRoom/actions/runs/31979203821 — the `tag` job failed, and `release` was correctly skipped (no cascading failure, which was the point of the previous fix) but no `latest` release got published.

Fix: add `actions/checkout@v7` as the first step of the `tag` job, matching what the old SourceKnight-based workflow did.